### PR TITLE
Bugsnag payload improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func Work(er bugsnack.ErrorReporter) {
     for {
         _, err := DoSomethingThatMightBreak()
         if err != nil {
-            er.Report(context.TODO(), err, &bugsnagMetadata{})
+            er.Report(context.TODO(), err)
             continue
         }
         time.Sleep(time.Second)
@@ -67,7 +67,7 @@ func Work(er bugsnack.ErrorReporter) {
     for {
         _, err := DoSomethingThatMightBreak()
         if err != nil {
-            er.Report(context.TODO(), err, &bugsnagMetadata{
+            er.ReportWithMetadata(context.TODO(), err, &bugsnagMetadata{
                 errorClass: "network.timeout",
                 context: "fetchWorker",
                 groupingHash: "timeouts", // https://docs.bugsnag.com/product/error-grouping/#custom-grouping-hash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func Work(er bugsnack.ErrorReporter) {
     for {
         _, err := DoSomethingThatMightBreak()
         if err != nil {
-            er.Report(context.TODO(), err)
+            er.Report(context.TODO(), err, &bugsnagMetadata{})
             continue
         }
         time.Sleep(time.Second)
@@ -55,6 +55,46 @@ func main() {
     // do something blocking while the background routine runs
 }
 ```
+
+# Metadata Support
+
+You may provide optional `errorClass`, `context`, `groupingHash`, `severity` and arbitrary `eventMetadata`:
+
+```go
+import "runtime"
+
+func Work(er bugsnack.ErrorReporter) {
+    for {
+        _, err := DoSomethingThatMightBreak()
+        if err != nil {
+            er.Report(context.TODO(), err, &bugsnagMetadata{
+                errorClass: "network.timeout",
+                context: "fetchWorker",
+                groupingHash: "timeouts", // https://docs.bugsnag.com/product/error-grouping/#custom-grouping-hash
+                severity: "info",
+                eventMetadata: &hashstruct.Hash{
+                    "data": hashstruct.Hash{
+                        "os": runtime.GOOS,
+                    },
+                    "key1": "value1",
+                    "key2": "value2",
+                    "arbitraryData": hashstruct.Hash{
+                        "goVersion": runtime.Version(),
+                        "nested": hashstruct.Hash{
+                            "nestedKey": "value",
+                        },
+                    },
+                },
+            })
+            continue
+        }
+        time.Sleep(time.Second)
+    }
+}
+```
+
+Please follow docs at https://docs.bugsnag.com/api/error-reporting/#json-payload
+
 
 # Advanced Usage
 

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -127,15 +127,11 @@ func (er *BugsnagReporter) newEvent(err *error.Error, metadata *bugsnagMetadata)
 		event["context"] = metadata.context
 	}
 
-	if !isZeroInterface(metadata.eventMetadata) {
+	if !metadata.eventMetadata.IsZeroInterface() {
 		event["metaData"] = metadata.eventMetadata
 	}
 
 	return &event
-}
-
-func isZeroInterface(i interface{}) bool {
-	return i == reflect.Zero(reflect.TypeOf(i)).Interface()
 }
 
 func populateMetadata(metadata *bugsnagMetadata, err *error.Error) {

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -89,9 +89,9 @@ func (er *BugsnagReporter) newPayload(depth int, err error) map[string]interface
 				"PayloadVersion": "2",
 				"exceptions": []map[string]interface{}{
 					{
-						"errorClass": err.Error(),
 						"message":    stack.Caller(depth).String(),
 						"stacktrace": formatStack(c),
+						"errorClass": reflect.TypeOf(err).String(),
 					},
 				},
 				"severity": "error",

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -36,6 +36,15 @@ type bugsnagMetadata struct {
 	eventMetadata *hashstruct.Hash
 }
 
+func (metadata *bugsnagMetadata) populateMetadata(err *error.Error) {
+	if metadata.errorClass == "" {
+		metadata.errorClass = reflect.TypeOf(err).String()
+	}
+	if metadata.severity == "" {
+		metadata.severity = "error"
+	}
+}
+
 func (er *BugsnagReporter) ReportWithMetadata(ctx context.Context, newErr interface{}, metadata *bugsnagMetadata) {
 	payload := er.newPayload(error.New(newErr), metadata)
 
@@ -81,7 +90,7 @@ func (er *BugsnagReporter) Report(ctx context.Context, newErr interface{}) {
 }
 
 func (er *BugsnagReporter) newPayload(err *error.Error, metadata *bugsnagMetadata) *hashstruct.Hash {
-	populateMetadata(metadata, err)
+	metadata.populateMetadata(err)
 
 	return &hashstruct.Hash{
 		"apiKey": er.APIKey,
@@ -132,15 +141,6 @@ func (er *BugsnagReporter) newEvent(err *error.Error, metadata *bugsnagMetadata)
 	}
 
 	return &event
-}
-
-func populateMetadata(metadata *bugsnagMetadata, err *error.Error) {
-	if metadata.errorClass == "" {
-		metadata.errorClass = reflect.TypeOf(err).String()
-	}
-	if metadata.severity == "" {
-		metadata.severity = "error"
-	}
 }
 
 func formatStack(s stack.CallStack) []hashstruct.Hash {

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -101,7 +101,6 @@ func (er *BugsnagReporter) newPayload(depth int, err error) map[string]interface
 				"device": map[string]interface{}{
 					"hostname": host,
 				},
-				"context": fmt.Sprint(reflect.TypeOf(err)),
 			},
 		},
 	}

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/fromatob/bugsnack/error"
+	"github.com/fromatob/bugsnack/hashstruct"
 )
 
 func TestErrorReporter(t *testing.T) {
@@ -21,7 +23,22 @@ func TestErrorReporter(t *testing.T) {
 		Backup:       nil,
 	}
 
-	er.Report(context.Background(), error.New("bugsnag test"))
+	er.Report(context.Background(), error.New("bugsnag test"), &bugsnagMetadata{
+		groupingHash: "net.timeout",
+		eventMetadata: &hashstruct.Hash{
+			"data": hashstruct.Hash{
+				"os": runtime.GOOS,
+			},
+			"key1": "value1",
+			"key2": "value2",
+			"arbitraryData": hashstruct.Hash{
+				"goVersion": runtime.Version(),
+				"nested": hashstruct.Hash{
+					"nestedKey": "value",
+				},
+			},
+		},
+	})
 }
 
 func TestNestedErrorReporter(t *testing.T) {
@@ -37,5 +54,5 @@ func TestNestedErrorReporter(t *testing.T) {
 			Backup:       nil,
 		}}}
 
-	er.Report(context.Background(), error.New("bugsnag multireporter test"))
+	er.Report(context.Background(), error.New("bugsnag multireporter test"), &bugsnagMetadata{})
 }

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -2,10 +2,11 @@ package bugsnack
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/fromatob/bugsnack/error"
 )
 
 func TestErrorReporter(t *testing.T) {
@@ -20,7 +21,7 @@ func TestErrorReporter(t *testing.T) {
 		Backup:       nil,
 	}
 
-	er.Report(context.Background(), errors.New("bugsnag test"))
+	er.Report(context.Background(), error.New("bugsnag test"))
 }
 
 func TestNestedErrorReporter(t *testing.T) {
@@ -36,5 +37,5 @@ func TestNestedErrorReporter(t *testing.T) {
 			Backup:       nil,
 		}}}
 
-	er.Report(context.Background(), errors.New("bugsnag multireporter test"))
+	er.Report(context.Background(), error.New("bugsnag multireporter test"))
 }

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -2,6 +2,7 @@ package bugsnack
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"runtime"
@@ -23,7 +24,9 @@ func TestErrorReporter(t *testing.T) {
 		Backup:       nil,
 	}
 
-	er.Report(context.Background(), error.New("bugsnag test"), &bugsnagMetadata{
+	er.Report(context.Background(), errors.New("bugsnag error test"))
+
+	er.ReportWithMetadata(context.Background(), error.New("bugsnag test"), &bugsnagMetadata{
 		groupingHash: "net.timeout",
 		eventMetadata: &hashstruct.Hash{
 			"data": hashstruct.Hash{
@@ -54,5 +57,5 @@ func TestNestedErrorReporter(t *testing.T) {
 			Backup:       nil,
 		}}}
 
-	er.Report(context.Background(), error.New("bugsnag multireporter test"), &bugsnagMetadata{})
+	er.Report(context.Background(), error.New("bugsnag multireporter test"))
 }

--- a/error/error.go
+++ b/error/error.go
@@ -1,0 +1,45 @@
+package error
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/fromatob/bugsnack/internal/stack"
+)
+
+// Error is an error with an attached stacktrace
+type Error struct {
+	Err        error
+	Stacktrace stack.CallStack
+}
+
+// Error returns the underlying error's message
+func (b *Error) Error() string {
+	return b.Err.Error()
+}
+
+// New makes an Error from the given value. If it's already an Error
+// then it will be used directly. Possible values are: string, error, *Error
+// Any other types will be processed by fallback and converted to an error with
+// its string representation
+func New(e interface{}) *Error {
+	var err error
+	// Arrays start at 1 ¯\_(ツ)_/¯
+	stacktrace := stack.Trace()[1:]
+
+	switch e := e.(type) {
+	case *Error:
+		return e
+	case error:
+		err = e
+	case string:
+		err = errors.New(e)
+	default:
+		err = fmt.Errorf("%v", e)
+	}
+
+	return &Error{
+		Err:        err,
+		Stacktrace: stacktrace,
+	}
+}

--- a/error_reporter.go
+++ b/error_reporter.go
@@ -11,7 +11,7 @@ import (
 
 // An ErrorReporter is used to Report errors
 type ErrorReporter interface {
-	Report(ctx context.Context, err *error.Error)
+	Report(ctx context.Context, err *error.Error, metadata *bugsnagMetadata)
 }
 
 // A MultiReporter is capable of sending a single error
@@ -22,13 +22,13 @@ type MultiReporter struct {
 
 // Report sends the same error to all underlying Reporters
 // concurrently.
-func (mr *MultiReporter) Report(ctx context.Context, err *error.Error) {
+func (mr *MultiReporter) Report(ctx context.Context, err *error.Error, metadata *bugsnagMetadata) {
 	var wg sync.WaitGroup
 	for _, er := range mr.Reporters {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, er ErrorReporter) {
 			defer wg.Done()
-			er.Report(ctx, err)
+			er.Report(ctx, err, metadata)
 		}(&wg, er)
 	}
 	wg.Wait()

--- a/error_reporter.go
+++ b/error_reporter.go
@@ -11,7 +11,7 @@ import (
 
 // An ErrorReporter is used to Report errors
 type ErrorReporter interface {
-	Report(ctx context.Context, err *error.Error, metadata *bugsnagMetadata)
+	Report(ctx context.Context, err interface{})
 }
 
 // A MultiReporter is capable of sending a single error
@@ -22,13 +22,13 @@ type MultiReporter struct {
 
 // Report sends the same error to all underlying Reporters
 // concurrently.
-func (mr *MultiReporter) Report(ctx context.Context, err *error.Error, metadata *bugsnagMetadata) {
+func (mr *MultiReporter) Report(ctx context.Context, err interface{}) {
 	var wg sync.WaitGroup
 	for _, er := range mr.Reporters {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, er ErrorReporter) {
 			defer wg.Done()
-			er.Report(ctx, err, metadata)
+			er.Report(ctx, err)
 		}(&wg, er)
 	}
 	wg.Wait()

--- a/hashstruct/hash.go
+++ b/hashstruct/hash.go
@@ -1,0 +1,3 @@
+package hashstruct
+
+type Hash map[string]interface{}

--- a/hashstruct/hash.go
+++ b/hashstruct/hash.go
@@ -1,3 +1,9 @@
 package hashstruct
 
+import "reflect"
+
 type Hash map[string]interface{}
+
+func (hash *Hash) IsZeroInterface() bool {
+	return hash == reflect.Zero(reflect.TypeOf(hash)).Interface()
+}


### PR DESCRIPTION
The PR makes it possible to define a custom `errorClass`, `severity`,  `context`, `groupingHash` OR add `eventMetadata` to the error event.

Also fixes the `Stacktrace`, now it shows the trace started from the place where error was reported, excluding internal calls of `bugsnack` package